### PR TITLE
Update Themes/default/css/tp-style.css

### DIFF
--- a/Themes/default/css/tp-style.css
+++ b/Themes/default/css/tp-style.css
@@ -2365,11 +2365,13 @@ div.tp_half21 {
 		overflow:hidden!important;
 	 	max-width:100%;
 	}
-	.lrON input.input_text,
-	.leftpanelOn input.input_text,
-	.rightpanelOn input.input_text	{
-		width:97%;
-	}
+/* very specific fixes dealing width responsive curve in 2.0 */
+	.lrON input[name="subject"], input[name="evtitle"], input[name="secret_question"], .lrON #edit_poll fieldset input, .lrON select[name="targetboard"], 
+	.leftpanelOn input[name="subject"], input[name="evtitle"], input[name="secret_question"], .leftpanelOn #edit_poll fieldset input, .leftpanelOn select[name="targetboard"],
+	.rightpanelOn input[name="subject"], input[name="evtitle"], input[name="secret_question"], .rightpanelOn #edit_poll fieldset input, .rightpanelOn select[name="targetboard"]	{
+		width:90%;
+	}	
+		
 	.inner a {
 		/* These are technically the same, but use both */
 		overflow-wrap: break-word;


### PR DESCRIPTION
Since I saw layout changes in areas that they were not needed I have reviewed the specific area's where the screen sizes were pushed due to the display: table layout and I specifically targetted the elements in question. 

Mostly dus to input fields with a "size=" style larger than 40 
This is pretty annoying, partly due to the code of old curve, but it may also affect future responsive themes, since the widely used max-width css setting is ignored while in the table display...

This can be merged for 1.6.0. 

We need to think about what to do with this going forward...