### PR TITLE
Fix for duplicate attachments

### DIFF
--- a/Sources/TPortal.php
+++ b/Sources/TPortal.php
@@ -1310,13 +1310,12 @@ function doTPfrontpage() {{{
 				COALESCE(mem.real_name, m.poster_name) AS real_name, m.poster_time AS date, mem.avatar, mem.posts, mem.date_registered AS date_registered, mem.last_login AS last_login,
 				COALESCE(a.id_attach, 0) AS id_attach, a.filename, a.attachment_type AS attachment_type, t.id_board AS category, b.name AS category_name,
 				t.num_replies AS numreplies, t.id_topic AS id, m.id_member AS author_id, t.num_views AS views, t.num_replies AS replies, t.locked,
-				COALESCE(thumb.id_attach, 0) AS thumb_id, thumb.filename AS thumb_filename, mem.email_address AS email_address
+				mem.email_address AS email_address
 			FROM {db_prefix}topics AS t
             INNER JOIN {db_prefix}messages AS m
 			    ON m.id_msg = t.id_first_msg
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
 			LEFT JOIN {db_prefix}attachments AS a ON (a.id_member = mem.id_member AND a.attachment_type !=3)
-			LEFT JOIN {db_prefix}attachments AS thumb ON (t.id_first_msg = thumb.id_msg AND thumb.attachment_type = 3)
 			LEFT JOIN {db_prefix}boards AS b ON (b.id_board = t.id_board)
 			WHERE t.id_first_msg IN ({array_int:posts})
 			ORDER BY m.{raw:catsort} DESC
@@ -1353,13 +1352,7 @@ function doTPfrontpage() {{{
 
             $topic_ids = array();
 			while($row = $smcFunc['db_fetch_assoc']($request)) {
-                // FIX for duplicate attachments
-                if(in_array($row['id'], $topic_ids)) {
-                    continue;
-                }
-                else {
-                    $topic_ids[] = $row['id'];
-                }
+                $topic_ids[] = $row['id'];
 
                 if(TPUtil::shortenString($row['body'], $context['TPortal']['frontpage_limit_len'])) {
 					$row['readmore'] = '... <p class="tp_readmore"><strong><a href="'. $scripturl. '?topic='. $row['id']. '">'. $txt['tp-readmore']. '</a></strong></p>';
@@ -1368,6 +1361,23 @@ function doTPfrontpage() {{{
                 // Turn the body back to bbc so the parse_bbc called later doesn't break....
                 $row['body']            = html_to_bbc($row['body']);
 
+				// get the thumb data
+				$request2 =  $smcFunc['db_query']('', '
+		        	SELECT t.num_views AS views, t.num_replies AS replies, t.locked, COALESCE(thumb.id_attach, 0) AS thumb_id, thumb.filename AS thumb_filename
+                    FROM {db_prefix}topics AS t
+			        LEFT JOIN {db_prefix}attachments AS thumb 
+                        ON ( t.id_first_msg = thumb.id_msg AND thumb.attachment_type = 3 )
+			        WHERE t.id_topic = ({int:id})',
+			        array(
+				        'id' => $row['id'],
+			        )
+		        );
+
+				$data					= $smcFunc['db_fetch_assoc']($request2);
+				$row['thumb_id']		= isset($data['thumb_id']) ? $data['thumb_id'] : 0;
+				$row['thumb_filename']	= isset($data['thumb_filename']) ? $data['thumb_filename'] : 0;
+				$smcFunc['db_free_result']($request2);
+				
 				// some needed addons
 				$row['rendertype'] = 'bbc';
 				$row['frame'] = 'theme';

--- a/Themes/default/TParticle.template.php
+++ b/Themes/default/TParticle.template.php
@@ -395,7 +395,7 @@ function template_submitarticle()
 						', $txt['tp-illustration'], '
 					</dt>
 					<dd>
-						<div class="article_icon" style="background: top right url(' , $boardurl , '/tp-files/tp-articles/illustrations/' , !empty($mg['illustration']) ? $mg['illustration'] : 'TPno_illustration.png' , ')no-repeat;"></div><br>
+						<div class="article_icon"><img src="' , $boardurl , '/tp-files/tp-articles/illustrations/' , !empty($mg['illustration']) ? $mg['illustration'] : 'TPno_illustration.png' , '"></div><br>
 					</dd>
 					<dt>
 						<label for="tp_article_illustration">', $txt['tp-illustration2'], '</label>

--- a/Themes/default/TPortalAdmin.template.php
+++ b/Themes/default/TPortalAdmin.template.php
@@ -1446,8 +1446,12 @@ function template_articons()
 			{
 				echo '
 					<div class="smalltext padding-div" style="float:left;">
-						<div class="article_icon" style="background: top right url(' . $icon['background'] . ') no-repeat;"></div>
-						<input type="checkbox" name="artillustration'.$icon['id'].'" id="artillustration'.$icon['id'].'" style="vertical-align: top;" value="'.$icon['file'].'"  /> <label style="vertical-align: top;"  for="artiillustration'.$icon['id'].'">'.$txt['tp-remove'].'</label>
+						<div style="width: 110px; height: 110px;text-align:center;">
+							<div class="article_icon"><img src="' . $icon['background'] . '"></div>
+						</div>
+						<div>
+							<input type="checkbox" name="artillustration'.$icon['id'].'" id="artillustration'.$icon['id'].'" style="vertical-align: top;" value="'.$icon['file'].'"  /> <label style="vertical-align: top;"  for="artiillustration'.$icon['id'].'">'.$txt['tp-remove'].'</label>
+						</div>
 					</div>
 							';
 				$alt = !$alt;

--- a/Themes/default/TPsubs.template.php
+++ b/Themes/default/TPsubs.template.php
@@ -1591,7 +1591,7 @@ function article_picturecolumn($render = true)
 		$data = '
 	<div class="article_picture" style="background-image: url(' . $boardurl . '/tp-files/tp-articles/illustrations/' . $context['TPortal']['article']['illustration'] . ');"></div>';
     }
-	elseif(!empty($context['TPortal']['article']['illustration']) && isset($context['TPortal']['article']['boardnews']) && (isset($context['TPortal']['use_attachment'])==1)) {
+	elseif(!empty($context['TPortal']['article']['illustration']) && isset($context['TPortal']['article']['boardnews']) && ($context['TPortal']['use_attachment']==1)) {
 		$data = '
 	    <div class="article_picture"><img src="' . $context['TPortal']['article']['illustration'] . '"></div>';
 	}

--- a/Themes/default/TPsubs.template.php
+++ b/Themes/default/TPsubs.template.php
@@ -1190,8 +1190,8 @@ function article_renders($type = 1, $single = false, $first = false)
 		$code = '
 	<div style="overflow: hidden;">
 		<div></div>
-		' . ($usetitlestyle ? '<div class="'. $divheader .'">' : '<div>') . '
-		' . ($usetitlestyle ? '<h3 class="' . $headerstyle . ' article_title">{article_title}&nbsp;</h3>' :  '<h3 class="article_title">{article_title} </h3>') . '
+			' . ($usetitlestyle ? '<div class="'. $divheader .'">' : '<div>') . '
+			' . ($usetitlestyle ? '<h3 class="' . $headerstyle . ' article_title">{article_title}&nbsp;</h3>' :  '<h3 class="article_title">{article_title} </h3>') . '
 		</div>
 		<div' . ($useframestyle ? ' class="' .$divbody. '" ' : '') . '>
 			<div class="article_info' . ($useframestyle ? '' : '') . '">
@@ -1331,16 +1331,17 @@ function article_renders($type = 1, $single = false, $first = false)
 		';
 	}
 	elseif($type == 4)
+	// Layout type: articles + icons
 	{
 		$code = '
 	<div class="tparticle">
-		<div class="article_picturecolumn">{article_picturecolumn}</div>
 		<div class="render4">
 			<div></div>
 			' . ($showtitle ? '<div class="cat_bar"><h3 class="catbg">{article_title} </h3></div>': '<div></div>') . '
 		<div' . ($useframestyle ? ' class="' .$divbody. '" ' : '') . '>
 			<div class="article_info">
-		' . (!$single ? '{article_avatar}' : '') .  '
+				<div class="article_picturecolumn">{article_picturecolumn}</div>
+				' . (!$single ? '{article_avatar}' : '') .  '
 				{article_author}
 				{article_category}
 				{article_date}
@@ -1350,20 +1351,21 @@ function article_renders($type = 1, $single = false, $first = false)
 				{article_options}
 				{article_print}
 			</div>
+			<p class="clearthefloat"></p>
+			<div class="tp_underline"></div>
 			<div class="article_padding">{article_text}
-			' . (!isset($context['TPortal']['article']['boardnews']) && !$single ? '{article_bookmark}' : '') . '
-			' . (isset($context['TPortal']['article']['boardnews']) ? '{article_boardnews}' : '') . '
+				' . (!isset($context['TPortal']['article']['boardnews']) && !$single ? '{article_bookmark}' : '') . '
+				' . (isset($context['TPortal']['article']['boardnews']) ? '{article_boardnews}' : '') . '
 			</div>
 			' . (($useframestyle && !$single) ? '<span class="botslice"><span></span></span>' : '') . '
 			' . ($single ? '
-
-			<div class="tp_container">
-				{article_bookmark}
-				{article_moreauthor}
+				<div class="tp_container">
+					{article_bookmark}
+					{article_moreauthor}
+				</div>
+				{article_morelinks}
+				{article_comments}' : '') . '
 			</div>
-			{article_morelinks}
-			{article_comments}' : '') . '
-		</div>
 		</div>
 	</div>';
 	}
@@ -1457,16 +1459,19 @@ function article_renders($type = 1, $single = false, $first = false)
 		$code = $context['TPortal']['frontpage_template'];
 	}
 	elseif($type == 8)
+	// Layout type: articles + icons2
 	{
 		$code = '
-<div class="tborder" style="margin-bottom: 5px;">
-	<div class="tparticle' . (isset($context['TPortal']['article']['boardnews']) ? ' windowbg' : ' windowbg') . '" style="margin: 0;">
-	<span class="topslice"><span></span></span>
-		<div class="article_picturecolumn tp_pad">{article_picturecolumn}</div>
-		<div class="render4 tp_pad">
-			<h2 class="article_title" style="padding-left: 0;">{article_title} </h2>
+	<div class="tparticle">
+		<div class="' . (isset($context['TPortal']['article']['boardnews']) ? ' windowbg' : ' windowbg') . '" style="margin: 0;">
+		<span class="topslice"><span></span></span>
+			<div class="render4">
+				<div class="article_header">
+					<div class="article_picturecolumn">{article_picturecolumn}</div>
+					<h2 class="article_title" style="padding-left: 0;">{article_title} </h2>
+				</div>
 			<div class="article_info">
-		' . (!$single ? '{article_avatar}' : '') .  '
+				' . (!$single ? '{article_avatar}' : '') .  '
 				{article_author}
 				{article_category}
 				{article_date}
@@ -1476,6 +1481,7 @@ function article_renders($type = 1, $single = false, $first = false)
 				{article_options}
 				{article_print}
 			</div>
+			<div class="tp_underline"></div>
 			<div class="article_padding">{article_text}
 			' . (!isset($context['TPortal']['article']['boardnews']) && !$single ? '{article_bookmark}' : '') . '
 			' . (isset($context['TPortal']['article']['boardnews']) ? '{article_boardnews}' : '') . '
@@ -1487,12 +1493,12 @@ function article_renders($type = 1, $single = false, $first = false)
 				{article_bookmark}
 				{article_moreauthor}
 			</div>
-			{article_morelinks}
-			{article_comments}' : '') . '
+				{article_morelinks}
+				{article_comments}' : '') . '
 		</div>
-	<span class="botslice"><span></span></span>
-	</div>
-</div>';
+		<span class="botslice"><span></span></span>
+		</div>
+	</div>';
 	}
 	elseif($type == 9)
 	{
@@ -1589,7 +1595,7 @@ function article_picturecolumn($render = true)
 
 	if(!empty($context['TPortal']['article']['illustration']) && !isset($context['TPortal']['article']['boardnews'])) {
 		$data = '
-	<div class="article_picture" style="background-image: url(' . $boardurl . '/tp-files/tp-articles/illustrations/' . $context['TPortal']['article']['illustration'] . ');"></div>';
+	<div class="article_picture" ><img src="' . $boardurl . '/tp-files/tp-articles/illustrations/' . $context['TPortal']['article']['illustration'] . '"></div>';
     }
 	elseif(!empty($context['TPortal']['article']['illustration']) && isset($context['TPortal']['article']['boardnews']) && ($context['TPortal']['use_attachment']==1)) {
 		$data = '
@@ -1597,7 +1603,7 @@ function article_picturecolumn($render = true)
 	}
     else {
 		$data = '
-	<div class="article_picture" style="background-image: url(' . $settings['tp_images_url'] . '/TPno_illustration.png);"></div>';
+	<div class="article_picture"><img src="' . $settings['tp_images_url'] . '/TPno_illustration.png"></div>';
     }
 
     if($render) {

--- a/Themes/default/css/tp-responsive.css
+++ b/Themes/default/css/tp-responsive.css
@@ -175,7 +175,7 @@
 		width:100%!important;
 	/* Avatar + Article ON for articles*/
 	}
-	.tp_responsive .article_picturecolumn {
+/*	.tp_responsive .article_picturecolumn {
 		float:none!important;
 		width:100%!important;
 	/* Picture + Article ON for articles*/
@@ -184,9 +184,6 @@
 		background-position: center;
 	}
 	.tp_responsive .render2 {
-		margin: 4px 0 0 0!important;
-	}
-	.tp_responsive .render4 {
 		margin: 4px 0 0 0!important;
 	}
 	.dl_itemgrid {

--- a/Themes/default/css/tp-style.css
+++ b/Themes/default/css/tp-style.css
@@ -164,6 +164,9 @@ h3.article_info {
 .article_info span:last-of-type {
 	border-right: none;
 }
+.article_author span:last-of-type {
+	border-right: none;
+}
 .article_authorinfo {
 	overflow: hidden;
 }
@@ -357,23 +360,37 @@ img.tp_social {
 .article_icon {
 	border: 1px solid #CCCCCC;
 	border: 1px solid rgba(204, 204, 204, 0.5);
-	height: 128px;
+	max-height: 98px;
 	overflow: hidden;
-	width: 128px;
+	width: 98px;
+}
+.admin-area .article_icon img {
+	max-width: 100%;
+	width: 100%;
 }
 /* render 4 */
 .render4 {
-	margin: 0 0 0 135px;
+	margin: 0 0 0 0;
 }
 .render4 h2 {
+	font-size: 1.2em;
 	font-weight: bold;
 	overflow: hidden;
 }
+.render4 .windowbg {
+	margin-top: 0 !important;
+}
+.article_header {
+	line-height: 1.6em;
+	overflow: hidden;
+	padding: 1em 1em 0 1em;
+}
 .article_picturecolumn {
 	float: left;
+	margin: 0 1em 0 0;
 	overflow: hidden;
 	text-align: center;
-	width: 130px;
+	width: 100px;
 }
 .article_picturecolumn img {
 	width: 100%;
@@ -381,8 +398,17 @@ img.tp_social {
 .article_picture {
 	background-position: top right;
 	background-repeat: no-repeat;
-	height: 128px;
-	width: 128px;
+	height: auto;
+	max-height: 98px;
+	width: 98px;
+}
+.render4 .article_info {
+	border-bottom: none;
+}
+.tp_underline {
+	border-bottom: #DDDDDD;
+	border-bottom: 1px solid rgba(221, 221, 221, 0.5);
+	margin: 0 1em 0 1em;
 }
 .article_boardnews {
 	font-size: 0.8em;
@@ -941,6 +967,9 @@ img.theme_icon {
 }
 /* SMF2.1 styles */
 /* Added these styles for 2.1 Curve to override new styles in admin sections */
+.tparticle .windowbg {
+	padding: 0;
+}
 .admintable > .windowbg {
 	border: none;
 	border-radius: 0;

--- a/Themes/default/css/tp-style.css
+++ b/Themes/default/css/tp-style.css
@@ -371,8 +371,12 @@ img.tp_social {
 }
 .article_picturecolumn {
 	float: left;
+	overflow: hidden;
 	text-align: center;
 	width: 130px;
+}
+.article_picturecolumn img {
+	width: 100%;
 }
 .article_picture {
 	background-position: top right;

--- a/Themes/default/languages/TPortalAdmin.english-utf8.php
+++ b/Themes/default/languages/TPortalAdmin.english-utf8.php
@@ -248,7 +248,7 @@ $txt['tp-nosubmissions'] = 'Currently there are no submissions awaiting approval
 
 // Icons
 $txt['tp-adminicons7'] = 'Article icons to be used in category layouts.';
-$txt['tp-adminiconsinfo'] = 'PNG, JPG or GIF, Max-size: 500KB. Images will be resized so the shortest side is 128 px, while retaining aspect ratio. Note that the top right area of the image will be used as article icon.';
+$txt['tp-adminiconsinfo'] = 'PNG, JPG or GIF, Max-size: 500KB. Images will be resized so the shortest side is 128 px, while retaining aspect ratio. Note that the top area of the image will be used as article icon.';
 $txt['tp-adminicons6'] = 'Upload a new article icon';
 
 // Add-Edit Article Category

--- a/Themes/default/languages/TPortalAdmin.english.php
+++ b/Themes/default/languages/TPortalAdmin.english.php
@@ -248,7 +248,7 @@ $txt['tp-nosubmissions'] = 'Currently there are no submissions awaiting approval
 
 // Icons
 $txt['tp-adminicons7'] = 'Article icons to be used in category layouts.';
-$txt['tp-adminiconsinfo'] = 'PNG, JPG or GIF, Max-size: 500KB. Images will be resized so the shortest side is 128 px, while retaining aspect ratio. Note that the top right area of the image will be used as article icon.';
+$txt['tp-adminiconsinfo'] = 'PNG, JPG or GIF, Max-size: 500KB. Images will be resized so the shortest side is 128 px, while retaining aspect ratio. Note that the top area of the image will be used as article icon.';
 $txt['tp-adminicons6'] = 'Upload a new article icon';
 
 // Add-Edit Article Category


### PR DESCRIPTION
This fixes the issue with the duplicate attachments and the number of topics showing on the frontpage.

Tino, can you review this please? It does the trick, but I would rather have the main query return just one thumbnail. See my try in issue #708 