### PR TITLE
Update TPShout.php

### DIFF
--- a/Sources/TPShout.php
+++ b/Sources/TPShout.php
@@ -122,17 +122,19 @@ function TPShoutLoad()
             $context['html_headers'] .= '
             <script type="text/javascript"><!-- // --><![CDATA[
             $(document).ready(function() {
-                $("#tp_shout").keydown(function (event) {
-                    if((event.metaKey || event.ctrlKey) && event.keyCode == 13) {
-                        tp_shout_key_press = true;
-                        // set a 100 millisecond timeout for the next key press
-                        window.setTimeout(function() { tp_shout_key_press = false; }, 100);
-                        TPupdateShouts(\'save\');
-                    }
-                    else if (event.keyCode == 13) {
-                        event.preventDefault();
-                    }
-                });
+				if ($("#tp_shout")) {
+					$("#tp_shout").keydown(function (event) {
+						if((event.metaKey || event.ctrlKey) && event.keyCode == 13) {
+							tp_shout_key_press = true;
+							// set a 100 millisecond timeout for the next key press
+							window.setTimeout(function() { tp_shout_key_press = false; }, 100);
+							TPupdateShouts(\'save\');
+						}
+						else if (event.keyCode == 13) {
+							event.preventDefault();
+						}
+					});
+				}
             });
             // ]]></script>';
         }
@@ -141,11 +143,13 @@ function TPShoutLoad()
         $context['html_headers'] .= '
             <script type="text/javascript"><!-- // --><![CDATA[
             $(document).ready(function() {
-                $("#tp_shout").keydown(function (event) {
-                    if (event.keyCode == 13) {
-                        event.preventDefault();
-                    }
-                });
+				if ($("#tp_shout")) {
+					$("#tp_shout").keydown(function (event) {
+						if (event.keyCode == 13) {
+							event.preventDefault();
+						}
+					});
+				}
             });
             // ]]></script>';
     }


### PR DESCRIPTION
Check if the shout container exists prior to checking event triggers from said container.
People may not have the shoutbox in operation meaning the page would be void of the container id.

JQuery doesn't check if the container exists prior to manipulating the DOM.
The page seems to throw JS errors from this file for the above even though no blocks are being displayed.
(tested on the forum page)
The JS errors can cause other scripts to malfunction.

Signed-off-by: Chen Zhen <github.underdog@gmail.com>