### PR TITLE
Some fixes

### DIFF
--- a/Sources/TPBlock.php
+++ b/Sources/TPBlock.php
@@ -161,7 +161,7 @@ function getBlocks() {{{
 	}
 
     // any cat listings from blocks?
-    if(isset($test_catbox)) {
+    if(isset($test_catbox) && !empty($fetch_article_titles)) {
         $tpArticle  = new TPArticle();
         $categories = $tpArticle->getArticlesInCategory($fetch_article_titles, false, true);
         if (!isset($context['TPortal']['blockarticle_titles'])) {

--- a/Themes/default/TPBlockLayout.template.php
+++ b/Themes/default/TPBlockLayout.template.php
@@ -436,16 +436,16 @@ function template_editblock()
 						<dt>'.$txt['tp-rssblock-useutf8'].'</dt>
 						<dd>
 							<input type="radio" id="tp_block_var1utf" name="tp_block_var1" value="1" ' , $context['TPortal']['blockedit']['var1']=='1' ? ' checked' : '' ,' required><label for="tp_block_var1utf">'.$txt['tp-utf8'].'</label><br>
-							<input type="radio" id="tp_block_var1iso" name="tp_block_var1" value="0" ' , ($context['TPortal']['blockedit']['var1']=='0' || $context['TPortal']['blockedit']['var1']=='') ? ' checked' : '' ,'><label for="tp_block_var1iso">'.$txt['tp-iso'].'</label>
+							<input type="radio" id="tp_block_var1iso" name="tp_block_var1" value="0" ' , $context['TPortal']['blockedit']['var1']<>'1' ? ' checked' : '' ,'><label for="tp_block_var1iso">'.$txt['tp-iso'].'</label>
 						</dd>
 						<dt>'.$txt['tp-rssblock-showonlytitle'].'</dt>
 						<dd>
 							<input type="radio" id="tp_block_var2yes" name="tp_block_var2" value="1" ' , $context['TPortal']['blockedit']['var2']=='1' ? ' checked' : '' ,' required><label for="tp_block_var2yes">'.$txt['tp-yes'].'</label>
-							<input type="radio" id="tp_block_var2no" name="tp_block_var2" value="0" ' , ($context['TPortal']['blockedit']['var2']=='0' || $context['TPortal']['blockedit']['var2']=='') ? ' checked' : '' ,'><label for="tp_block_var2no">'.$txt['tp-no'], '</label>
+							<input type="radio" id="tp_block_var2no" name="tp_block_var2" value="0" ' , $context['TPortal']['blockedit']['var2']<>'1' ? ' checked' : '' ,'><label for="tp_block_var2no">'.$txt['tp-no'], '</label>
 						</dd>
 						<dt><label for="tp_block_var3">' . $txt['tp-rssblock-maxwidth'].'</label></dt>
 						<dd>
-							<input type="number" id="tp_block_var3" name="tp_block_var3" value="' , $context['TPortal']['blockedit']['var3'],'" style="width: 6em">
+							<input id="tp_block_var3" name="tp_block_var3" value="' , $context['TPortal']['blockedit']['var3'],'" style="width: 6em">
 						</dd>
 						<dt><label for="tp_block_var4">' . $txt['tp-rssblock-maxshown'].'</label></dt>
 						<dd>
@@ -546,7 +546,7 @@ function template_editblock()
 						</dd>
 						<dt><label for="tp_block_var1">'.$txt['tp-catboxheight'].'</label></dt>
 						<dd>
-							<input type="number" id="tp_block_var1" name="tp_block_var1" value="' , ((!is_numeric($context['TPortal']['blockedit']['var1'])) || (($context['TPortal']['blockedit']['var1']) == 0) ? '15' : $context['TPortal']['blockedit']['var1']) ,'" style="width: 6em" min="2" required> em
+							<input type="number" id="tp_block_var1" name="tp_block_var1" value="' , ((!is_numeric($context['TPortal']['blockedit']['var1'])) || (($context['TPortal']['blockedit']['var1']) == 0) ? '15' : $context['TPortal']['blockedit']['var1']) ,'" style="width: 6em" min="1" required> em
 						</dd>
 						<dt>'.$txt['tp-catboxauthor'].'</dt>
 						<dd>
@@ -593,6 +593,11 @@ function template_editblock()
 			elseif($context['TPortal']['blockedit']['type']=='2'){
 				echo '
 					<div>' . $txt['tp-newsdesc'] . '</div>';
+			}
+// Block type: Search
+			elseif($context['TPortal']['blockedit']['type']=='4'){
+				echo '
+					<div>' . $txt['tp-searchdesc'] . '</div>';
 			}
 			else {
 				echo '

--- a/Themes/default/TPsubs.template.php
+++ b/Themes/default/TPsubs.template.php
@@ -950,7 +950,7 @@ function TPortal_articlebox()
 	global $context;
 
 	if(isset($context['TPortal']['blockarticles'][$context['TPortal']['blockarticle']]))
-		echo '<div class="block_article">', 	template_blockarticle() , '</div>';
+		echo '<div class="block_article">', template_blockarticle() ,'</div>';
 }
 
 // blocktype 19: Articles in a Category

--- a/Themes/default/css/tp-style.css
+++ b/Themes/default/css/tp-style.css
@@ -1235,7 +1235,7 @@ code.bbc_code {
 	margin: 8px 0;
 	padding: 4px;
 	vertical-align: middle;
-	width: 100%;
+	max-width: 100%;
 }
 .rss_body h1, .rss_body h2, .rss_body h3, .rss_body h4, .rss_body h5, .rss_body h6 {
 	font-size: 1em;

--- a/Themes/default/languages/TPortalAdmin.english.php
+++ b/Themes/default/languages/TPortalAdmin.english.php
@@ -460,11 +460,11 @@ $txt['tp-ssi-topviews'] = 'Top Views';
 $txt['tp-rssblock'] = 'RSS feed ';
 $txt['tp-rssblock-showonlytitle'] = 'Display only titles?';
 $txt['tp-rssblock-useutf8'] = 'What encoding to use in this feed ';
-$txt['tp-utf8'] = 'UTF-8';
-$txt['tp-iso'] = 'ISO-8859-1 (default)';
+$txt['tp-utf8'] = 'UTF-8 <span class="smalltext">(default)</span>';
+$txt['tp-iso'] = 'ISO-8859-1';
 $txt['tp-rssblock-showavatar'] = 'Show avatars';
-$txt['tp-rssblock-maxwidth'] = 'Max width of rss feed';
-$txt['tp-rssblock-maxshown'] = 'Maximum number of items shown in rss feed ( 0 sets max to 20 )';
+$txt['tp-rssblock-maxwidth'] = 'Max width of rss feed<br><span class="smalltext">(include unit, such as px, % or em)</span>';
+$txt['tp-rssblock-maxshown'] = 'Maximum number of items shown in rss feed<br><span class="smalltext">(leave empty for default: 20)</span>';
 $txt['tp-showstatsbox'] = 'Display these stats in the article/downloads box';
 $txt['tp-showssibox'] = 'Display this SSI function in the box';
 $txt['tp-showuserbox'] = 'Display these items in the statbox';
@@ -485,7 +485,8 @@ $txt['tp-catboxauthor'] = 'Show author?';
 $txt['tp-catboxheight'] = 'Height of the article box before scrollbar';
 $txt['tp-insert'] = 'Insert code';
 $txt['tp-unreadreplies'] = 'Unread replies';
-$txt['tp-noblocktype'] = 'You have not specified a block type';
+$txt['tp-searchdesc'] = 'The search block presents the standard SMF search function in a block.';
+$txt['tp-noblocktype'] = 'You have not specified a block type or the block type has no settings.';
 
 // Menu manager
 $txt['tp-helpmenus'] = 'The built in menu manager allows you to create multiple menu\'s. These menu\'s are typically displayed in a block. You get all the features of blocks to display these menu\'s in different places along with choosing who gets to see the blocks based on permissions. Here you can edit the Internal menu of create and manage new menu\'s';


### PR DESCRIPTION
- Fixed RSS width block setting (not allowing to enter width unit)
- Fixed IMG width in RSS block: max-width 100% instead of width 100% 
- Fixed issue "Database error, given array of integer values is empty. (cat)" when switching to Articles in Category block without saving block settings
- Added 'default' text for block settings News block and Search block
- 