### PR TITLE
Don't load portal if guest only access

### DIFF
--- a/Sources/TPortal.php
+++ b/Sources/TPortal.php
@@ -89,6 +89,10 @@ function TPortal_init() {{{
 		return;
     }
 
+	if($modSettings['allow_guestAccess'] == '0' && $user_info['is_guest']) {
+		return;
+	}
+
 	if(loadLanguage('TPortal') == false) {
 		loadLanguage('TPortal', 'english');
     }


### PR DESCRIPTION
Disables all TinyPortal blocks etc if Guest Only Access is set