### PR TITLE
Fix for deprated messages PHP 8.1 and removed unused function

### DIFF
--- a/Sources/TPBlock.php
+++ b/Sources/TPBlock.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPListImages.php
+++ b/Sources/TPListImages.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - https://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPSearch.php
+++ b/Sources/TPSearch.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPShout.php
+++ b/Sources/TPShout.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPSubs.php
+++ b/Sources/TPSubs.php
@@ -668,7 +668,7 @@ if(!function_exists('htmlspecialchars_decode'))
     }
 }
 
-function TP_createtopic($title, $text, $icon, $board, $sticky = 0, $submitter)
+function TP_createtopic($title, $text, $icon, $board, $sticky = 0, $submitter = false)
 {
 	global $user_info, $board_info, $sourcedir;
 
@@ -842,7 +842,7 @@ function TPwysiwyg_setup()
 	}
 }
 
-function TPwysiwyg($textarea, $body, $upload = true, $uploadname, $use = 1, $showchoice = true)
+function TPwysiwyg($textarea, $body, $upload = true, $uploadname = false, $use = 1, $showchoice = true)
 {
 	global $user_info, $boardurl, $settings, $boarddir, $context, $txt, $scripturl;
 
@@ -1608,101 +1608,6 @@ function tp_hidebars($what = 'all' )
 	elseif($what=='lower')
 		$context['TPortal']['lowerpanel'] = 0;
 }
-
-function get_blockaccess($what, $front = false, $whichbar)
-{
-	global $context, $user_info;
-
-	$mylang = $user_info['language'];
-	$show = false;
-
-	// if empty return
-	if($what=='')
-	{
-		$show=false;
-		return $show;
-	}
-    // split up the access level
-    $levels = explode('|', $what);
-    foreach($levels as $level => $code){
-		$precode = substr($code,0, 6);
-		$body = explode(",", substr($code, 6));
-		if($precode == '')
-		{
-			// special case for frontpage
-			if(in_array('frontpage', $body) && !isset($_GET['action']) && !isset($_GET['board']) && !isset($_GET['topic']) && !isset($_GET['page']) && !isset($_GET['cat']))
-				$show = true;
-			// normal
-			if(in_array($context['TPortal']['action'], $body) || (isset($_GET['action']) && in_array($_GET['action'], $body)))
-				$show = true;
-			// special for forum
-			if(in_array('forumall', $body) && $context['TPortal']['in_forum'])
-				$show = true;
-			// if we are on post screen
-			if(isset($_GET['action']) && $_GET['action'] == 'post2' && in_array('post', $body))
-				$show = true;
-
-			// special for allpages!
-			if(in_array('allpages', $body))
-				$show = true;
-		}
-		elseif($precode == 'board='){
-			if(isset($_GET['board']) && in_array($_GET['board'], $body))
-				$show = true;
-			// show on all boards
-			if(isset($_GET['board']) && in_array('-1', $body))
-				$show = true;
-		}
-		elseif($precode == 'dlcat='){
-			if(isset($_GET['dl']) && substr($_GET['dl'], 0, 3) == 'cat' && in_array(substr($_GET['dl'], 3), $body))
-				$show = true;
-		}
-		elseif($precode == 'tpmod='){
-			if($context['TPortal']['action'] == 'tpmod' && isset($_GET[$body]))
-				$show = true;
-		}
-		elseif($precode == 'custo='){
-			if(isset($_GET['action']) && in_array($_GET['action'], $body))
-				$show = true;
-		}
-		elseif($precode == 'tpage=')
-		{
-			if(isset($context['TPortal']['currentpage']))
-			{
-				if(in_array($context['TPortal']['currentpage'], $body))
-					$show = true;
-			}
-			if($front && in_array($context['TPortal']['featured_article'], $body))
-				$show = true;
-		}
-		elseif($precode == 'tpcat='){
-			if(isset($_GET['cat']) && !isset($_GET['action']) && in_array($_GET['cat'], $body))
-				$show = true;
-			// also on the actual category
-			if(!empty($context['TPortal']['parentcat']) && in_array($context['TPortal']['parentcat'], $body))
-				$show = true;
-		}
-		elseif($precode == 'tlang=')
-		{
-			// if a language IS selected, use ONLY that, otherwise it will abide to the others
-			if(in_array($mylang, $body))
-				$show_lang = true;
-			else
-				$show_lang = false;
-		}
-		// code for modules
-		elseif($precode == 'modul='){
-			if($context['TPortal']['action'] == 'tpmod' && isset($_GET['dl']))
-				$show = true;
-		}
-    }
-	// check for language option
-	if(isset($show_lang) && $show == true)
-	{
-		$show = $show_lang;
-	}
-	return $show;
- }
 
 function TPgetlangOption($langlist, $set)
 {

--- a/Sources/TPSubs.php
+++ b/Sources/TPSubs.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPcommon.php
+++ b/Sources/TPcommon.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPdlmanager.php
+++ b/Sources/TPdlmanager.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPortal.php
+++ b/Sources/TPortal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Sources/TPortalAdmin.php
+++ b/Sources/TPortalAdmin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/TPBlockLayout.template.php
+++ b/Themes/default/TPBlockLayout.template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/TPShout.template.php
+++ b/Themes/default/TPShout.template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/TParticle.template.php
+++ b/Themes/default/TParticle.template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/TPdladmin.template.php
+++ b/Themes/default/TPdladmin.template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/TPortalAdmin.template.php
+++ b/Themes/default/TPortalAdmin.template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/TPsubs.template.php
+++ b/Themes/default/TPsubs.template.php
@@ -2584,7 +2584,7 @@ function template_tp_fatal_error()
 }
 
 // Format a time to make it look purdy.
-function tptimeformat($log_time, $show_today = true, $format)
+function tptimeformat($log_time, $show_today = true, $format = '%d %b %Y')
 {
 	global $context, $user_info, $txt, $modSettings, $smcFunc;
 

--- a/Themes/default/TPsubs.template.php
+++ b/Themes/default/TPsubs.template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/css/tp-responsive.css
+++ b/Themes/default/css/tp-responsive.css
@@ -1,6 +1,6 @@
 	/**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/css/tp-shout.css
+++ b/Themes/default/css/tp-shout.css
@@ -1,6 +1,6 @@
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/css/tp-style.css
+++ b/Themes/default/css/tp-style.css
@@ -1,6 +1,6 @@
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/Themes/default/languages/TPdlmanager.english.php
+++ b/Themes/default/languages/TPdlmanager.english.php
@@ -1,5 +1,5 @@
 <?php
-// Version: 2.1.1; TPdlmanager
+// Version: 2.2.0; TPdlmanager
 
 global $scripturl;
 

--- a/Themes/default/languages/TPhelp.english.php
+++ b/Themes/default/languages/TPhelp.english.php
@@ -1,5 +1,5 @@
 <?php
-// Version: 2.1.1; TPhelp
+// Version: 2.2.0; TPhelp
 
 // Credits
 $txt['tp-credit1'] = '

--- a/Themes/default/languages/TPortal.english.php
+++ b/Themes/default/languages/TPortal.english.php
@@ -1,5 +1,5 @@
 <?php
-// Version: 2.1.1; TPortal
+// Version: 2.2.0; TPortal
 
 global $txt, $context, $scripturl;
 

--- a/Themes/default/languages/TPortalAdmin.english.php
+++ b/Themes/default/languages/TPortalAdmin.english.php
@@ -1,5 +1,5 @@
 <?php
-// Version: 2.1.1; TPortalAdmin
+// Version: 2.2.0; TPortalAdmin
 
 // Menu
 $txt['tp-adminheader1'] = 'Settings & Frontpage';

--- a/TinyPortal/Admin.php
+++ b/TinyPortal/Admin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/TinyPortal/Article.php
+++ b/TinyPortal/Article.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/TinyPortal/Base.php
+++ b/TinyPortal/Base.php
@@ -11,7 +11,7 @@
  * author: tinoest - https://tinoest.co.uk
  * license: BSD-3-Clause
  *
- * @version 2.1.1
+ * @version 2.2.0
  *
  */
 namespace TinyPortal;

--- a/TinyPortal/Block.php
+++ b/TinyPortal/Block.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/TinyPortal/Database.php
+++ b/TinyPortal/Database.php
@@ -11,7 +11,7 @@
  * author: tinoest - https://tinoest.co.uk
  * license: BSD-3-Clause
  *
- * @version 2.1.1
+ * @version 2.2.0
  *
  */
 namespace TinyPortal;

--- a/TinyPortal/Integrate.php
+++ b/TinyPortal/Integrate.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0
@@ -284,7 +284,7 @@ class Integrate
         }
 
 
-        $string = '<a target="_blank" href="https://www.tinyportal.net" title="TinyPortal">TinyPortal 2.1.1</a> &copy; <a href="' . $scripturl . '?action=tportal;sa=credits" title="Credits">2005-2022</a>';
+        $string = '<a target="_blank" href="https://www.tinyportal.net" title="TinyPortal">TinyPortal 2.2.0</a> &copy; <a href="' . $scripturl . '?action=tportal;sa=credits" title="Credits">2005-2022</a>';
 
         if (SMF == 'SSI' || empty($context['template_layers']) || (defined('WIRELESS') && WIRELESS ) || strpos($buffer, $string) !== false)
             return $buffer;

--- a/TinyPortal/Shout.php
+++ b/TinyPortal/Shout.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/TinyPortal/Upload.php
+++ b/TinyPortal/Upload.php
@@ -11,7 +11,7 @@
  * author: tinoest - https://tinoest.co.uk
  * license: BSD-3-Clause
  *
- * @version 2.1.1
+ * @version 2.2.0
  *
  */
 namespace TinyPortal;

--- a/TinyPortal/Util.php
+++ b/TinyPortal/Util.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author tinoest - https://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0

--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
  * install.php
  *
  * @package TinyPortal
- * @version 2.1.1
+ * @version 2.2.0
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0
@@ -64,7 +64,7 @@ if ($manual) {
 	$render .= '
 	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 	<html xmlns="http://www.w3.org/1999/xhtml"><head>
-		<title>TinyPortal - v2.1.1 for '.$forumVersion.'</title>
+		<title>TinyPortal - v2.2.0 for '.$forumVersion.'</title>
 		 <link rel="stylesheet" type="text/css" href="'. $boardurl . '/Themes/default/css/index.css" />
 	</head><body>';
 }
@@ -78,7 +78,7 @@ $render .= '<div id="hidemenow" style="z-index: 200; margin-bottom: 1em; positio
     document.getElementById("hidemenow").style.overflow = "hidden";
     }
 </script>
-<div class="cat_bar" style="position:relative;"><a href="javascript:void(0)" style="position:absolute;top:5px;right:5px;font-weight:bold;color:red;" onclick="closeNav()"><img src="' . $boardurl . '/Themes/default/images/tinyportal/TPdelete2.png" alt="*" /></a><h3 class="catbg">Install/Upgrade TinyPortal v2.1.1 for '.$forumVersion.'<h3/></div>
+<div class="cat_bar" style="position:relative;"><a href="javascript:void(0)" style="position:absolute;top:5px;right:5px;font-weight:bold;color:red;" onclick="closeNav()"><img src="' . $boardurl . '/Themes/default/images/tinyportal/TPdelete2.png" alt="*" /></a><h3 class="catbg">Install/Upgrade TinyPortal v2.2.0 for '.$forumVersion.'<h3/></div>
 	<div class="windowbg middletext" style="padding: 2em; overflow: auto;">
 		<ul class="normallist" style="line-height: 1.7em;">';
 
@@ -419,7 +419,7 @@ $smcFunc['db_free_result']($request);
 
 $settings_array = array(
     // KEEP TRACK OF INTERNAL VERSION HERE
-    'version' => '2.1.1',
+    'version' => '2.2.0',
     'frontpage_title' => '',
     'showforumfirst' => '0',
     'hideadminmenu' => '0',

--- a/install.xml
+++ b/install.xml
@@ -3,7 +3,7 @@
 <modification xmlns="http://www.simplemachines.org/xml/modification" xmlns:smf="http://www.simplemachines.org/"> 
   
 	<id>bloc:tinyportal</id>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
 	<file name="$boarddir/index.php">
         <operation>
             <search position="replace"><![CDATA[writeLog();]]></search>

--- a/package-info.xml
+++ b/package-info.xml
@@ -4,7 +4,7 @@
 	<name>TinyPortal</name>
 	<id>bloc:tinyportal</id>
 	<type>modification</type>
-	<version>2.1.1</version>
+	<version>2.2.0</version>
 
 	<install for="2.0 - 2.0.99">
 		<redirect url="">Installed!</redirect>

--- a/readme_install20.txt
+++ b/readme_install20.txt
@@ -1,4 +1,4 @@
-Installing TinyPortal v2.1.1 for SMF2.0.x
+Installing TinyPortal v2.2.0 for SMF2.0.x
 
 [size=14pt][color=red][b]Important:[/b][/color][/size]
 [list]

--- a/readme_install21.txt
+++ b/readme_install21.txt
@@ -1,4 +1,4 @@
-Installing TinyPortal v2.1.1 for SMF2.1
+Installing TinyPortal v2.2.0 for SMF2.1
 
 [size=14pt][color=red][b]Important:[/b][/color][/size]
 [list]

--- a/readme_uninstall.txt
+++ b/readme_uninstall.txt
@@ -1,4 +1,4 @@
-Uninstalling TinyPortal v2.1.1 for SMF2.0.x and SMF2.1.x
+Uninstalling TinyPortal v2.2.0 for SMF2.0.x and SMF2.1.x
 
 [size=14pt][b]Thanks for using TinyPortal![/b][/size]
 


### PR DESCRIPTION
Hi tino, I think this works to get the deprecated messgaes out of this version without affecting the core code. 

I cannot see any use of the blockaccess function, and deactivating it seems to have no negatove impact. 
What's you opinion on putting these changes into the next release? 

We could leave the better solution (changing the order of arguments in the functions) for a next release...