### PR TITLE
Trying out TinyPortal Upgrade via SMF

### DIFF
--- a/TinyPortal/Integrate.php
+++ b/TinyPortal/Integrate.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package TinyPortal
- * @version 2.2.1
+ * @version 2.2.2
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0
@@ -284,7 +284,7 @@ class Integrate
         }
 
 
-        $string = '<a target="_blank" href="https://www.tinyportal.net" title="TinyPortal">TinyPortal 2.2.1</a> &copy; <a href="' . $scripturl . '?action=tportal;sa=credits" title="Credits">2005-2022</a>';
+        $string = '<a target="_blank" href="https://www.tinyportal.net" title="TinyPortal">TinyPortal 2.2.2</a> &copy; <a href="' . $scripturl . '?action=tportal;sa=credits" title="Credits">2005-2022</a>';
 
         if (SMF == 'SSI' || empty($context['template_layers']) || (defined('WIRELESS') && WIRELESS ) || strpos($buffer, $string) !== false)
             return $buffer;

--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
  * install.php
  *
  * @package TinyPortal
- * @version 2.2.1
+ * @version 2.2.2
  * @author IchBin - http://www.tinyportal.net
  * @founder Bloc
  * @license MPL 2.0
@@ -60,7 +60,7 @@ if ($manual) {
 	$render .= '
 	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 	<html xmlns="http://www.w3.org/1999/xhtml"><head>
-		<title>TinyPortal - v2.2.1 for '.$forumVersion.'</title>
+		<title>TinyPortal - v2.2.2 for '.$forumVersion.'</title>
 		 <link rel="stylesheet" type="text/css" href="'. $boardurl . '/Themes/default/css/index.css" />
 	</head><body>';
 }
@@ -74,7 +74,7 @@ $render .= '<div id="hidemenow" style="z-index: 200; margin-bottom: 1em; positio
     document.getElementById("hidemenow").style.overflow = "hidden";
     }
 </script>
-<div class="cat_bar" style="position:relative;"><a href="javascript:void(0)" style="position:absolute;top:5px;right:5px;font-weight:bold;color:red;" onclick="closeNav()"><img src="' . $boardurl . '/Themes/default/images/tinyportal/TPdelete2.png" alt="*" /></a><h3 class="catbg">Install/Upgrade TinyPortal v2.2.1 for '.$forumVersion.'<h3/></div>
+<div class="cat_bar" style="position:relative;"><a href="javascript:void(0)" style="position:absolute;top:5px;right:5px;font-weight:bold;color:red;" onclick="closeNav()"><img src="' . $boardurl . '/Themes/default/images/tinyportal/TPdelete2.png" alt="*" /></a><h3 class="catbg">Install/Upgrade TinyPortal v2.2.2 for '.$forumVersion.'<h3/></div>
 	<div class="windowbg middletext" style="padding: 2em; overflow: auto;">
 		<ul class="normallist" style="line-height: 1.7em;">';
 
@@ -480,7 +480,7 @@ if($convertaccess) {
 // now we process all settings
 $settings_array = array(
     // KEEP TRACK OF INTERNAL VERSION HERE
-    'version' => '2.2.1',
+    'version' => '2.2.2',
     'frontpage_title' => '',
     'showforumfirst' => '0',
     'hideadminmenu' => '0',

--- a/package-info.xml
+++ b/package-info.xml
@@ -4,7 +4,7 @@
 	<name>TinyPortal</name>
 	<id>bloc:tinyportal</id>
 	<type>modification</type>
-	<version>2.2.1</version>
+	<version>2.2.2</version>
 
 	<install for="2.0 - 2.0.99">
 		<redirect url="">Installed!</redirect>
@@ -73,6 +73,19 @@
 		<database>install.php</database>
 		<code>do_hooks.php</code>
 	</install>
+
+	<upgrade from="all" for="2.1.* - 2.1.99">
+		<redirect url="">Upgraded!</redirect>
+		<require-dir name="Themes" destination="$boarddir" />
+		<require-dir name="Sources" destination="$boarddir" />
+		<require-dir name="TinyPortal" destination="$boarddir" />
+		<require-dir name="tp-files" destination="$boarddir" />
+		<require-dir name="tp-downloads" destination="$boarddir" />
+		<require-dir name="tp-images" destination="$boarddir" />
+		<readme parsebbc="true">readme_install21.txt</readme>
+		<database>install.php</database>
+	</upgrade>
+
 	<uninstall for="2.1.* - 2.1.99">
 		<readme parsebbc="true">readme_uninstall.txt</readme>
 		<remove-dir name="$themedir/images/tinyportal" />

--- a/readme_install20.txt
+++ b/readme_install20.txt
@@ -1,4 +1,4 @@
-Installing TinyPortal v2.2.1 for SMF2.0.x
+Installing TinyPortal v2.2.2 for SMF2.0.x
 
 [size=14pt][color=red][b]Important:[/b][/color][/size]
 [list]

--- a/readme_install21.txt
+++ b/readme_install21.txt
@@ -1,4 +1,4 @@
-Installing TinyPortal v2.2.1 for SMF2.1
+Installing TinyPortal v2.2.2 for SMF2.1
 
 [size=14pt][color=red][b]Important:[/b][/color][/size]
 [list]


### PR DESCRIPTION
Enable the option to upgrade TinyPortal for SMF 2.1, as we don't modify the core code. We can just replace all with this upgrade process, save's an uninstall and install 